### PR TITLE
Bump from rust:1.59-buster to rust:1.66-buster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.58
+          toolchain: 1.66
           override: true
           components: rustfmt,clippy
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ And if you see "Dev Container: Rust Template" in the bottom left corner, you're 
 ## The following are installed.
 
 - Docker image
-    - rust:1.59-buster
+    - rust:1.66-buster
 - CLI tools
     - git
     - cargo-edit

--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.59-buster
+FROM rust:1.66-buster
 
 RUN apt-get update && \
     apt-get -y install git && \


### PR DESCRIPTION
[こちらのQiita記事](https://qiita.com/schrosis/items/1d99b68ae00d3cdbf9e1)を拝読しながら手順に従っていたのですが、step3で依存性の解決に失敗しエラーが出ておりました。
Rustのバージョンを上げるとエラーが出なくなりましたので、取り急ぎPRを投げます。